### PR TITLE
fix: update date_of_birth field to birth_date in user registration

### DIFF
--- a/prisma/migrations/20250901161515_add_bundling_column/migration.sql
+++ b/prisma/migrations/20250901161515_add_bundling_column/migration.sql
@@ -1,0 +1,27 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `media_id` on the `competition_submission` table. All the data in the column will be lost.
+  - The values [s1,d3,d4] on the enum `user_pendidikan` will be removed. If these variants are still used in the database, this will fail.
+  - A unique constraint covering the columns `[name]` on the table `media` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropForeignKey
+ALTER TABLE `competition_submission` DROP FOREIGN KEY `competition_submission_media_id_fkey`;
+
+-- DropIndex
+DROP INDEX `competition_submission_media_id_key` ON `competition_submission`;
+
+-- AlterTable
+ALTER TABLE `competition_submission` DROP COLUMN `media_id`,
+    ADD COLUMN `submission_object` JSON NULL;
+
+-- AlterTable
+ALTER TABLE `event_participant` ADD COLUMN `bundling` ENUM('day1', 'day2', 'day1_day2') NULL,
+    ADD COLUMN `paid_for_user` BOOLEAN NULL;
+
+-- AlterTable
+ALTER TABLE `user` MODIFY `pendidikan` ENUM('sma', 'mahasiswa', 'lainnya') NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX `media_name_key` ON `media`(`name`);

--- a/src/services/event.service.js
+++ b/src/services/event.service.js
@@ -14,7 +14,7 @@ const registerUserIntoEvent = async (
     if (date_of_birth) {
         await prisma.user.update({
             where: { id: user_id },
-            data: { date_of_birth },
+            data: { birth_date: new Date(date_of_birth) },
         });
     }
 

--- a/src/validators/eventRegisterValidationSchema.js
+++ b/src/validators/eventRegisterValidationSchema.js
@@ -17,8 +17,8 @@ const eventRegisterSchema = Joi.object({
             "string.pattern.base":
                 "Phone number must be a valid international format.",
         }),
-    // 'date_of_born' is optional; provide if available, unlike other required fields
-    date_of_born: Joi.date()
+    // 'date_of_birth' is optional; provide if available, unlike other required fields
+    date_of_birth: Joi.date()
         .optional()
 });
 


### PR DESCRIPTION
@coderabbitai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Event registration now supports a date_of_birth field with improved birth date handling.
  - Event participants can choose bundling options: Day 1, Day 2, or both.
  - Registrations can be marked as paid by someone else.

- Changes
  - Education level choices simplified to SMA, Mahasiswa, or Lainnya.
  - Media names must be unique, which may require renaming duplicates.
  - Competition submissions now support structured submission data.

- Bug Fixes
  - Corrected registration field name from date_of_born to date_of_birth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->